### PR TITLE
babel-polyfill追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "presets": [
       "es2015"
     ]
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.26.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 /**
  * Validation error converter
  * @param err object

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
   dependencies:
     babel-runtime "^6.26.0"
     core-js "^2.5.0"


### PR DESCRIPTION
IEでこけちゃうみたいなのでポリフィル追加しました。
おそらくNuxt側とはbabelのバージョンが違いすぎるので必要なポリフィルが入らないようです（Nuxt側はこのポリフィルが要らないと判断してる？）。
せっかくなのでついでに@babel/coreに変えちゃおうと試してみましたがavaが動かなかったのでそのままにしてあります。